### PR TITLE
Improve typing game features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Too Type Too Furious
 
-Aplicación web de carreras de mecanografía. Permite registro de usuarios y jugar en modo individual o multijugador.
+Aplicación web de carreras de mecanografía. Permite registro de usuarios y jugar en modo individual o multijugador con un ranking de mejores tiempos.
 
 ## Requisitos
 
@@ -16,6 +16,11 @@ npm start
 ```
 
 Abrir `http://localhost:3000` en el navegador.
+
+La clasificación de mejores tiempos está disponible en `/scores` con filtros
+`?mode=single` o `?mode=multi`.
+
+El texto de cada partida individual se obtiene desde `/text`.
 
 Ejecutar pruebas:
 

--- a/public/multi.js
+++ b/public/multi.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const textEl = document.getElementById('text');
   const input = document.getElementById('input');
   const opponent = document.getElementById('opponent');
+  const result = document.getElementById('result');
 
   socket.emit('joinRace');
   socket.on('startRace', text => {
@@ -16,9 +17,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   input.addEventListener('input', () => {
     socket.emit('progress', input.value.length);
+    const progress = Math.min((input.value.length / targetText.length) * 100, 100);
+    result.textContent = `Progreso: ${progress.toFixed(0)}%`;
     if (input.value === targetText) {
       const time = (Date.now() - start) / 1000;
-      alert(`¡Ganaste! Tiempo: ${time}s`);
+      fetch('/score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ time, mode: 'multi' })
+      }).then(() => {
+        alert(`¡Ganaste! Tiempo: ${time}s`);
+        window.location.href = '/scores';
+      });
     }
   });
 

--- a/public/single.js
+++ b/public/single.js
@@ -1,17 +1,25 @@
-const texts = [
-  'Hola mundo de la mecanografía.',
-  'Practica para ser el más rápido.',
-  'Too Type Too Furious en acción.'
-];
-const text = texts[Math.floor(Math.random() * texts.length)];
+let text = '';
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('text').textContent = text;
+  fetch('/text')
+    .then(r => r.text())
+    .then(t => {
+      text = t;
+      document.getElementById('text').textContent = text;
+    });
   const input = document.getElementById('input');
-  const start = Date.now();
+  let start;
   input.addEventListener('input', () => {
+    if (!start) start = Date.now();
     if (input.value === text) {
       const time = (Date.now() - start) / 1000;
-      document.getElementById('result').textContent = `Tiempo: ${time}s`;
+      fetch('/score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ time, mode: 'single' })
+      }).then(() => {
+        document.getElementById('result').textContent = `Tiempo: ${time}s`;
+        window.location.href = '/scores';
+      });
     }
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -8,7 +8,7 @@ beforeAll(() => {
 });
 
 test('register and login user', async () => {
-  const agent = request(app);
+  const agent = request.agent(app);
   await agent
     .post('/register')
     .send('username=test&password=pass')
@@ -17,4 +17,25 @@ test('register and login user', async () => {
     .post('/login')
     .send('username=test&password=pass');
   expect(res.status).toBe(302);
+
+  await agent
+    .post('/score')
+    .send({ time: 5, mode: 'single' })
+    .expect(200);
+
+  await agent
+    .post('/score')
+    .send({ time: 6, mode: 'multi' })
+    .expect(200);
+
+  const scorePage = await agent.get('/scores');
+  expect(scorePage.text).toContain('test');
+
+  const singlePage = await agent.get('/scores?mode=single');
+  expect(singlePage.text).toContain('single');
+  expect(singlePage.text).not.toMatch(/<td>multi<\/td>/);
+
+  const textRes = await agent.get('/text');
+  expect(textRes.status).toBe(200);
+  expect(textRes.text.length).toBeGreaterThan(0);
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -10,6 +10,9 @@
     <ul>
       <li><a href="/single">Juego individual</a></li>
       <li><a href="/multi">Carrera multijugador</a></li>
+      <li><a href="/scores">Clasificación global</a></li>
+      <li><a href="/scores?mode=single">Ranking individual</a></li>
+      <li><a href="/scores?mode=multi">Ranking multijugador</a></li>
     </ul>
   <% } else { %>
     <a href="/login">Iniciar sesión</a> | <a href="/register">Registrarse</a>

--- a/views/multi.ejs
+++ b/views/multi.ejs
@@ -7,9 +7,13 @@
 </head>
 <body>
   <h1>Carrera multijugador</h1>
+  <% if (!user) { %>
+    <p style="color:red">Inicia sesión para guardar tu puntuación.</p>
+  <% } %>
   <div id="text"></div>
   <textarea id="input" rows="3" cols="60"></textarea>
   <div id="opponent"></div>
+  <div id="result"></div>
   <a href="/">Volver</a>
 </body>
 </html>

--- a/views/scores.ejs
+++ b/views/scores.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Clasificación</title>
+</head>
+<body>
+  <% if (user) { %>
+    <p>Bienvenido, <%= user.username %> | <a href="/logout">Salir</a></p>
+  <% } else { %>
+    <a href="/login">Iniciar sesión</a> | <a href="/register">Registrarse</a>
+  <% } %>
+  <h1>Mejores tiempos</h1>
+  <p>
+    <a href="/scores" <% if (!mode) { %>style="font-weight:bold"<% } %>>Todos</a> |
+    <a href="/scores?mode=single" <% if (mode==='single') { %>style="font-weight:bold"<% } %>>Individual</a> |
+    <a href="/scores?mode=multi" <% if (mode==='multi') { %>style="font-weight:bold"<% } %>>Multijugador</a>
+  </p>
+  <table border="1">
+    <tr><th>Usuario</th><th>Modo</th><th>Tiempo (s)</th></tr>
+    <% scores.forEach(s => { %>
+      <tr><td><%= s.username %></td><td><%= s.mode %></td><td><%= s.time %></td></tr>
+    <% }) %>
+  </table>
+  <a href="/">Volver</a>
+</body>
+</html>

--- a/views/single.ejs
+++ b/views/single.ejs
@@ -6,6 +6,9 @@
 </head>
 <body>
   <h1>Juego individual</h1>
+  <% if (!user) { %>
+    <p style="color:red">Inicia sesión para guardar tu puntuación.</p>
+  <% } %>
   <div id="text"></div>
   <textarea id="input" rows="3" cols="60"></textarea>
   <div id="result"></div>


### PR DESCRIPTION
## Summary
- filter scoreboard by mode and random text API
- fetch text from API and display progress in multiplayer
- show login reminders on game pages
- update tests for new routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688caec98a948326bc7b0919f94c8241